### PR TITLE
CMake Clang on Windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,10 +99,10 @@ include_directories(AFTER "${SRCDIR}" "${SRCDIR}/contrib/liblzma"
                           "${SRCDIR}/contrib/liblzma/lzma" "${SRCDIR}/contrib/liblzma/rangecoder"
                           "${SRCDIR}/contrib/liblzma/simple")
 add_definitions(-DHAVE_BOOL)
-if (MSVC)
+if (MSVC OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND WIN32))
   include_directories(AFTER "msinttypes")
   add_definitions(-D_UNICODE -DUNICODE)
-endif (MSVC)
+endif (MSVC OR (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND WIN32))
 
 set(BRUNSLI_SRC "")
 add_stem2file(BRUNSLI_SRC "${SRCDIR}/contrib/brunsli/c/common/%STEM%.cc"


### PR DESCRIPTION
Clang has a history of producing better code than MSVC, afaik because MSVC won't optimize based on strict aliasing. Here's two lines to make clang work out of the box.